### PR TITLE
perf(incremental): не гонять min/max-учёт через обход списка слушателей

### DIFF
--- a/src/main/java/org/antlr/v4/runtime/IncrementalParser.java
+++ b/src/main/java/org/antlr/v4/runtime/IncrementalParser.java
@@ -158,6 +158,16 @@ public abstract class IncrementalParser extends Parser implements ParseTreeListe
    */
 
   @Override
+  protected void triggerEnterRuleEvent() {
+    enterEveryRule(_ctx);
+  }
+
+  @Override
+  protected void triggerExitRuleEvent() {
+    exitEveryRule(_ctx);
+  }
+
+  @Override
   public void enterEveryRule(ParserRuleContext ctx) {
     // During rule entry, we push a new min/max token state.
     pushCurrentTokenToMinMax();


### PR DESCRIPTION
## Суть

`IncrementalParser` регистрирует сам себя как единственный `ParseTreeListener` и делает min/max-учёт в `enterEveryRule`/`exitEveryRule`. На каждое правило `Parser.enterRule`/`exitRule` вызывают `triggerEnter/ExitRuleEvent`, которые итерируют список `_parseListeners` и виртуально диспетчеризуют вызов.

Слушатель ровно один (сам парсер), поэтому `triggerEnter/ExitRuleEvent` переопределены и зовут `enterEveryRule`/`exitEveryRule` напрямую — без итерации списка и виртуальной диспетчеризации. Поведение не меняется.

## Замечание по эффекту

Сам по себе выигрыш в пределах шума (медиана −1–2%): из 9.5% под `triggerEnter/ExitRuleEvent` в baseline бóльшая часть — это **работа** внутри обработчиков (push/pop min/max + объединения), которую снимает PR #59, а не оболочка диспетчеризации (JIT и так инлайнит её как мономорфную).

Этот PR — естественное дополнение к #59: поверх int-представления он убирает уже ненужную listener-обвязку. Логически его стоит мёржить после #59 (оба правят `IncrementalParser.java` в соседних участках — при мёрже одного второй может потребовать тривиального разрешения конфликта в комментарии).

## Проверка

`./gradlew compileJava` + инкрементальные тесты — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcbkpN3BeFBFmhPzxPVBei)_