### PR TITLE
Публикация Javadoc на GitHub Pages

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -35,12 +35,17 @@ jobs:
           cache: gradle
       - name: Generate Javadoc
         run: ./gradlew javadoc --stacktrace
+      - name: Stage site
+        run: |
+          mkdir -p _site/javadoc
+          cp -r build/docs/javadoc/. _site/javadoc/
+          echo '<!DOCTYPE html><meta charset="utf-8"><meta http-equiv="refresh" content="0; url=javadoc/">' > _site/index.html
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload Javadoc artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: build/docs/javadoc
+          path: _site
 
   deploy:
     needs: build

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Документация
 
-Javadoc публикуется на GitHub Pages: [https://1c-syntax.github.io/antlr/](https://1c-syntax.github.io/antlr/)
+Javadoc публикуется на GitHub Pages: [https://1c-syntax.github.io/antlr/javadoc/](https://1c-syntax.github.io/antlr/javadoc/)
 
 ## Благодарности
 


### PR DESCRIPTION
## Что сделано

Добавлена автоматическая публикация Javadoc на GitHub Pages.

### Изменения

- **`.github/workflows/publish-javadoc.yml`** — новый workflow:
  - Триггеры: push в `develop`, публикация релиза, ручной запуск (`workflow_dispatch`).
  - Job `build`: генерирует документацию через `./gradlew javadoc` (JDK 21, temurin, кэш Gradle), раскладывает её в подпапку `javadoc/` и добавляет в корень редирект на неё, затем загружает артефакт Pages.
  - Job `deploy`: разворачивает артефакт на GitHub Pages официальными `actions/deploy-pages`.
  - Настроены `permissions` (`pages: write`, `id-token: write`) и `concurrency` для безопасных деплоев.
- **`README.md`** — добавлен раздел «Документация» со ссылкой на опубликованный Javadoc.

### Адреса после деплоя

- `https://1c-syntax.github.io/antlr/` → редирект на Javadoc
- `https://1c-syntax.github.io/antlr/javadoc/` → документация

### ⚠️ Требуется разовая настройка

В настройках репозитория нужно один раз выбрать источник Pages: **Settings → Pages → Build and deployment → Source → GitHub Actions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UgHS2BabXVQFY76tzkFQFo)_